### PR TITLE
Support migration filenames pattern

### DIFF
--- a/tusker/__init__.py
+++ b/tusker/__init__.py
@@ -105,14 +105,10 @@ class Tusker:
         with self.createdb('migrations') as migrations_engine:
             with migrations_engine.begin() as migrations_cursor:
                 self.log('Creating migrated schema...')
-                for filename in sorted(os.listdir(self.config.migrations.directory)):
+                for filename in self._get_migrations():
                     if not filename.endswith('.sql'):
                         continue
                     self.log('- {}'.format(filename))
-                    filename = os.path.join(
-                        self.config.migrations.directory,
-                        filename
-                    )
                     execute_sql_file(migrations_cursor, filename)
             yield migrations_engine
 
@@ -179,6 +175,16 @@ class Tusker:
         finally:
             cursor.close()
 
+    def _get_migrations(self):
+        migrations = []
+        if self.config.migrations.filename:
+            migrations = glob(self.config.migrations.filename)
+        else:
+            migrations = [
+                os.path.join(self.config.migrations.directory, filename)
+                for filename in os.listdir(self.config.migrations.directory)
+            ]
+        return sorted(migrations)
 
 def cmd_diff(args, cfg: Config):
     tusker = Tusker(cfg, args.verbose)

--- a/tusker/config.py
+++ b/tusker/config.py
@@ -57,8 +57,15 @@ class MigrationsConfig:
 
     def __init__(self, data):
         data = ConfigReader(data)
-        self.directory = data.get('directory', str, True) or 'migrations'
+        self.directory = data.get('directory', str, False)
         self.filename = data.get('filename', str, False)
+        if not self.directory and not self.filename:
+            self.directory = 'migrations'
+        elif self.directory and self.filename:
+            raise ConfigError.invalid(
+                'migrations',
+                'directory and filename parameters are mutually exclusive',
+            )
 
     def __str__(self):
         return 'MigrationsConfig({!r})'.format(self.__dict__)

--- a/tusker/config.py
+++ b/tusker/config.py
@@ -58,6 +58,7 @@ class MigrationsConfig:
     def __init__(self, data):
         data = ConfigReader(data)
         self.directory = data.get('directory', str, True) or 'migrations'
+        self.filename = data.get('filename', str, False)
 
     def __str__(self):
         return 'MigrationsConfig({!r})'.format(self.__dict__)


### PR DESCRIPTION
Recently I had a need to support migration tool using slightly different migration structure not supported directly by Tusker: ``migrations/<dbname>/<timestamp>_name/{up,down}.sql`` (Hasura migrations). And Tusker happened to be so wonderful tool that I couldn't refuse to use it so I decided to implement a new feature.

Here new optional ``filename`` parameter is supported in the ``migrations`` section. This parameter defines a glob pattern for migration filenames and is mutually exclusive with ``directory``.