### PR TITLE
fix(schema-check): align check with schema diff output

### DIFF
--- a/crates/tusker-schema/tests/non_actionable_column_order.rs
+++ b/crates/tusker-schema/tests/non_actionable_column_order.rs
@@ -1,0 +1,137 @@
+use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use tokio::task::JoinHandle;
+use tokio_postgres::{Client, Config, NoTls};
+use tusker_schema::{diff::DiffSql, inspect, models::schema::join_sql, Inspection};
+
+static NEXT_DB_ID: AtomicU64 = AtomicU64::new(0);
+
+struct TestDatabase {
+    admin_client: Client,
+    db_client: Client,
+    db_connection: JoinHandle<()>,
+    dbname: String,
+}
+
+impl TestDatabase {
+    async fn new() -> Result<Self> {
+        let url = env::var("PG_URL").expect("Missing environment variable: PG_URL");
+        let mut admin_config: Config = url.parse()?;
+        admin_config.dbname("postgres");
+        let (admin_client, admin_connection) = admin_config.connect(NoTls).await?;
+        tokio::spawn(admin_connection);
+
+        let unique_id = NEXT_DB_ID.fetch_add(1, Ordering::Relaxed);
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let dbname = format!("tusker_schema_test_{}_{}", timestamp, unique_id);
+        admin_client
+            .simple_query(&format!("CREATE DATABASE {}", dbname))
+            .await?;
+
+        let mut db_config: Config = url.parse()?;
+        db_config.dbname(&dbname);
+        let (db_client, db_connection_fut) = db_config.connect(NoTls).await?;
+        let db_connection = tokio::spawn(async move {
+            let _ = db_connection_fut.await;
+        });
+
+        Ok(Self {
+            admin_client,
+            db_client,
+            db_connection,
+            dbname,
+        })
+    }
+
+    async fn cleanup(self) -> Result<()> {
+        let TestDatabase {
+            admin_client,
+            db_client,
+            db_connection,
+            dbname,
+        } = self;
+        drop(db_client);
+        let _ = db_connection.await;
+        admin_client
+            .simple_query(&format!("DROP DATABASE {} WITH (FORCE)", dbname))
+            .await?;
+        Ok(())
+    }
+}
+
+async fn inspect_sql(client: &mut Client, sql: &str) -> Result<Inspection> {
+    let txn = client.transaction().await?;
+    txn.simple_query(sql).await?;
+    let inspection = inspect(&txn.client()).await?;
+    txn.rollback().await?;
+    Ok(inspection)
+}
+
+#[tokio::test]
+async fn table_column_history_can_be_non_actionable_but_not_structurally_equal() {
+    let mut test_db = TestDatabase::new().await.unwrap();
+    let client = &mut test_db.db_client;
+
+    let canonical_sql = r#"
+        CREATE TABLE public.expense (
+            id integer NOT NULL,
+            name text NOT NULL,
+            unit text NOT NULL,
+            price integer NOT NULL,
+            cost integer NOT NULL,
+            creator_id text NOT NULL,
+            updater_id text
+        );
+    "#;
+
+    let historical_sql = r#"
+        CREATE TABLE public.expense (
+            id integer NOT NULL,
+            name text NOT NULL,
+            unit text NOT NULL,
+            cost integer NOT NULL,
+            creator_id text NOT NULL,
+            updater_id text
+        );
+
+        ALTER TABLE public.expense
+            DROP COLUMN cost,
+            ADD COLUMN cost_cents integer NOT NULL;
+
+        ALTER TABLE public.expense RENAME COLUMN cost_cents TO cost;
+        ALTER TABLE public.expense RENAME COLUMN cost TO price;
+
+        ALTER TABLE public.expense
+            ADD COLUMN internal_cost integer NOT NULL DEFAULT 0;
+        ALTER TABLE public.expense
+            ALTER COLUMN internal_cost DROP DEFAULT;
+        ALTER TABLE public.expense RENAME COLUMN internal_cost TO cost;
+    "#;
+
+    let canonical = inspect_sql(client, canonical_sql).await.unwrap();
+    let historical = inspect_sql(client, historical_sql).await.unwrap();
+
+    assert_ne!(
+        canonical, historical,
+        "inspection structs should differ due to column-order history"
+    );
+
+    let forward_sql = join_sql(canonical.diff(&historical).sql());
+    assert!(
+        forward_sql.trim().is_empty(),
+        "expected no actionable diff SQL, got: {}",
+        forward_sql
+    );
+
+    let reverse_sql = join_sql(historical.diff(&canonical).sql());
+    assert!(
+        reverse_sql.trim().is_empty(),
+        "expected no actionable reverse diff SQL, got: {}",
+        reverse_sql
+    );
+
+    test_db.cleanup().await.unwrap();
+}

--- a/crates/tusker/CHANGELOG.md
+++ b/crates/tusker/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Align `tusker schema check` with `tusker schema diff` by basing the check
+  result on actionable diff SQL output instead of strict in-memory inspection
+  equality.
+
 ## [0.6.1] - 2026-05-23
 
 ### Fixed

--- a/crates/tusker/src/cli/schema/check.rs
+++ b/crates/tusker/src/cli/schema/check.rs
@@ -2,11 +2,21 @@ use std::process::exit;
 
 use anyhow::Result;
 use clap::Parser;
-use tusker_schema::{diff::DiffSql, models::schema::join_sql};
+use tusker_schema::{diff::DiffSql, models::schema::join_sql, Inspection};
 
 use crate::{config::Config, db::DiffDatabase};
 
 use super::{diff::inspect_backend, Backend};
+
+fn has_actionable_changes(from: &Inspection, to: &Inspection) -> bool {
+    let diff = from.diff(to);
+    let has_schema_add_drop = !diff.a_only.is_empty() || !diff.b_only.is_empty();
+    if has_schema_add_drop {
+        true
+    } else {
+        !join_sql(diff.sql()).trim().is_empty()
+    }
+}
 
 #[derive(Copy, Clone, Debug, Parser)]
 pub(crate) struct CheckArgs {
@@ -34,13 +44,7 @@ pub(crate) async fn cmd(cfg: &Config, args: &CheckArgs) -> Result<()> {
     let to = inspect_backend(cfg, &mut db, args.to).await?;
     db.drop().await?;
 
-    let diff = from.diff(&to);
-    let has_schema_add_drop = !diff.a_only.is_empty() || !diff.b_only.is_empty();
-    let has_changes = if has_schema_add_drop {
-        true
-    } else {
-        !join_sql(diff.sql()).trim().is_empty()
-    };
+    let has_changes = has_actionable_changes(&from, &to);
 
     if !has_changes {
         println!("Schemas are identical");
@@ -49,5 +53,67 @@ pub(crate) async fn cmd(cfg: &Config, args: &CheckArgs) -> Result<()> {
         println!("Schemas differ: {} != {}", args.from, args.to);
         println!("Run `tusker diff` to see the differences");
         exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use tusker_schema::{
+        Inspection,
+        models::{r#enum::Enum, schema::Schema},
+    };
+
+    use super::has_actionable_changes;
+
+    fn inspection_with_schema(schema: Schema) -> Inspection {
+        let mut schemas = HashMap::new();
+        let _ = schemas.insert(schema.name.clone(), schema);
+        Inspection { schemas }
+    }
+
+    #[test]
+    fn reports_no_changes_when_diff_output_is_empty() {
+        let from = inspection_with_schema(Schema::new("public"));
+        let to = inspection_with_schema(Schema::new("public"));
+
+        assert!(!has_actionable_changes(&from, &to));
+    }
+
+    #[test]
+    fn reports_changes_for_schema_add_drop_guard() {
+        let from = inspection_with_schema(Schema::new("public"));
+        let to = inspection_with_schema(Schema::new("other"));
+
+        assert!(has_actionable_changes(&from, &to));
+    }
+
+    #[test]
+    fn reports_changes_when_actionable_sql_exists() {
+        let mut from_schema = Schema::new("public");
+        let _ = from_schema.enums.insert(
+            "ticket_state".into(),
+            Enum {
+                schema: "public".into(),
+                name: "ticket_state".into(),
+                labels: vec!["new".into()],
+            },
+        );
+
+        let mut to_schema = Schema::new("public");
+        let _ = to_schema.enums.insert(
+            "ticket_state".into(),
+            Enum {
+                schema: "public".into(),
+                name: "ticket_state".into(),
+                labels: vec!["new".into(), "assigned".into()],
+            },
+        );
+
+        let from = inspection_with_schema(from_schema);
+        let to = inspection_with_schema(to_schema);
+
+        assert!(has_actionable_changes(&from, &to));
     }
 }

--- a/crates/tusker/src/cli/schema/check.rs
+++ b/crates/tusker/src/cli/schema/check.rs
@@ -62,7 +62,11 @@ mod tests {
 
     use tusker_schema::{
         Inspection,
-        models::{r#enum::Enum, schema::Schema},
+        models::{
+            domain::{Domain, DomainConstraint},
+            r#enum::Enum,
+            schema::Schema,
+        },
     };
 
     use super::has_actionable_changes;
@@ -115,5 +119,57 @@ mod tests {
         let to = inspection_with_schema(to_schema);
 
         assert!(has_actionable_changes(&from, &to));
+    }
+
+    #[test]
+    fn ignores_non_actionable_non_enum_order_only_differences() {
+        let mut from_schema = Schema::new("public");
+        let _ = from_schema.domains.insert(
+            "positive_int".into(),
+            Domain {
+                schema: "public".into(),
+                name: "positive_int".into(),
+                base_type: "integer".into(),
+                default: None,
+                not_null: false,
+                constraints: vec![
+                    DomainConstraint {
+                        name: "positive".into(),
+                        definition: "CHECK ((VALUE > 0))".into(),
+                    },
+                    DomainConstraint {
+                        name: "below_limit".into(),
+                        definition: "CHECK ((VALUE < 1000))".into(),
+                    },
+                ],
+            },
+        );
+
+        let mut to_schema = Schema::new("public");
+        let _ = to_schema.domains.insert(
+            "positive_int".into(),
+            Domain {
+                schema: "public".into(),
+                name: "positive_int".into(),
+                base_type: "integer".into(),
+                default: None,
+                not_null: false,
+                constraints: vec![
+                    DomainConstraint {
+                        name: "below_limit".into(),
+                        definition: "CHECK ((VALUE < 1000))".into(),
+                    },
+                    DomainConstraint {
+                        name: "positive".into(),
+                        definition: "CHECK ((VALUE > 0))".into(),
+                    },
+                ],
+            },
+        );
+
+        let from = inspection_with_schema(from_schema);
+        let to = inspection_with_schema(to_schema);
+
+        assert!(!has_actionable_changes(&from, &to));
     }
 }

--- a/crates/tusker/src/cli/schema/check.rs
+++ b/crates/tusker/src/cli/schema/check.rs
@@ -2,6 +2,7 @@ use std::process::exit;
 
 use anyhow::Result;
 use clap::Parser;
+use tusker_schema::{diff::DiffSql, models::schema::join_sql};
 
 use crate::{config::Config, db::DiffDatabase};
 
@@ -32,7 +33,16 @@ pub(crate) async fn cmd(cfg: &Config, args: &CheckArgs) -> Result<()> {
     let from = inspect_backend(cfg, &mut db, args.from).await?;
     let to = inspect_backend(cfg, &mut db, args.to).await?;
     db.drop().await?;
-    if from == to {
+
+    let diff = from.diff(&to);
+    let has_schema_add_drop = !diff.a_only.is_empty() || !diff.b_only.is_empty();
+    let has_changes = if has_schema_add_drop {
+        true
+    } else {
+        !join_sql(diff.sql()).trim().is_empty()
+    };
+
+    if !has_changes {
         println!("Schemas are identical");
         Ok(())
     } else {


### PR DESCRIPTION
## Summary

Align schema check semantics with actionable schema diff output.

## Problem

`tusker check` retuns a failure (schemas differ) while `tusker diff` produced no actionable output.

I got into this situation after tusker generated a migration which include a reasonably complicated trigger function. 

Note this PR was generated with AI assistance. I've verified that its has resolved the issue I was facing.

## Root Cause

`check` used strict in-memory inspection equality, while users rely on `diff` output semantics.

## Changes

- Update schema check logic in `crates/tusker/src/cli/schema/check.rs`
- Determine change presence from generated diff SQL output
- Keep explicit schema add/drop guard
- Document behavior fix in `crates/tusker/CHANGELOG.md`

